### PR TITLE
create a SpotifyEmbed component

### DIFF
--- a/src/components/SpotifyEmbed/SpotifyEmbed.tsx
+++ b/src/components/SpotifyEmbed/SpotifyEmbed.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef } from 'react';
+
+interface SpotifyEmbedProps {
+	uri: string;
+}
+
+declare global {
+	interface Window {
+		onSpotifyIframeApiReady?: (IFrameAPI: any) => void;
+		SpotifyIframeApiReady?: boolean;
+		SpotifyIframeApi?: any;
+	}
+}
+
+const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ uri }) => {
+	const embedRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (window.SpotifyIframeApiReady) {
+			createEmbed();
+		} else if (!window.onSpotifyIframeApiReady) {
+			window.onSpotifyIframeApiReady = (IFrameAPI) => {
+				window.SpotifyIframeApiReady = true;
+				window.SpotifyIframeApi = IFrameAPI;
+				createEmbed();
+			};
+
+			const script = document.createElement('script');
+			script.src = 'https://open.spotify.com/embed-podcast/iframe-api/v1';
+			script.async = true;
+			document.body.appendChild(script);
+		}
+
+		function createEmbed() {
+			if (embedRef.current && window.SpotifyIframeApi) {
+				window.SpotifyIframeApi.createController(
+					embedRef.current,
+					{
+						uri,
+					},
+					(EmbedController: any) => {
+						console.log('Spotify Embed created successfully');
+					}
+				);
+			}
+		}
+
+		return () => {
+			// Cleanup if necessary
+		};
+	}, [uri]);
+
+	return <div ref={embedRef} />;
+};
+
+export default SpotifyEmbed;

--- a/src/components/SpotifyEmbedPlayer/SpotifyEmbedPlayer.tsx
+++ b/src/components/SpotifyEmbedPlayer/SpotifyEmbedPlayer.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef } from 'react';
 
 interface SpotifyEmbedProps {
 	uri: string;
+	width?: string;
+	height?: string;
 }
 
 declare global {
@@ -12,7 +14,11 @@ declare global {
 	}
 }
 
-const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ uri }) => {
+const SpotifyEmbedPlayer: React.FC<SpotifyEmbedProps> = ({
+	uri,
+	width = '100%',
+	height = '350px',
+}) => {
 	const embedRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -37,6 +43,8 @@ const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ uri }) => {
 					embedRef.current,
 					{
 						uri,
+						width,
+						height,
 					},
 					(EmbedController: any) => {
 						console.log('Spotify Embed created successfully');
@@ -48,9 +56,9 @@ const SpotifyEmbed: React.FC<SpotifyEmbedProps> = ({ uri }) => {
 		return () => {
 			// Cleanup if necessary
 		};
-	}, [uri]);
+	}, [uri, width, height]);
 
 	return <div ref={embedRef} />;
 };
 
-export default SpotifyEmbed;
+export default SpotifyEmbedPlayer;

--- a/src/components/SpotifyList/PodcastData.ts
+++ b/src/components/SpotifyList/PodcastData.ts
@@ -1,0 +1,162 @@
+export const podcastEpisodes = [
+	{
+		name: 'EP31:Finding Rizq - Contentment and Small Pleasures',
+		uri: 'spotify:episode:48uDebBFSKEXcbDXK8cvNZ',
+		date: '2024-07-21',
+	},
+	{
+		name: 'EP30:Present Bias and Future Focused Money Decisions',
+		uri: 'spotify:episode:0oJ2knzth9TYJf22VRZuek',
+		date: '2024-07-12',
+	},
+	{
+		name: 'EP29:Payday Routines',
+		uri: 'spotify:episode:1HnjQlBcLRghHnPBw09Z1b',
+		date: '2024-07-05',
+	},
+	{
+		name: 'EP28:Balancing Returns vs Costs',
+		uri: 'spotify:episode:0AQUJgx19MYmHZwOPW0dIA',
+		date: '2024-06-26',
+	},
+	{
+		name: 'EP27:Tawakkul and Personal Finance - Eid Special',
+		uri: 'spotify:episode:1rEvxlZWdYyD1KLvXWbCdr',
+		date: '2024-06-16',
+	},
+	{
+		name: 'EP26:How to Build Financial Resilience',
+		uri: 'spotify:episode:0dG5BjRyTVionNT7vQObKK',
+		date: '2024-06-08',
+	},
+	{
+		name: 'EP25:Comparing Shariah Compliant Investment Platforms',
+		uri: 'spotify:episode:2p9on8RcMFboItU2u3Hrkz',
+		date: '2024-06-01',
+	},
+	{
+		name: 'EP24:First-time Halal Investing',
+		uri: 'spotify:episode:56Utk9M3ekDiXOQzUCQb2C',
+		date: '2024-05-25',
+	},
+	{
+		name: 'EP23:Understanding NHS Pensions',
+		uri: 'spotify:episode:2pe1IgoDJ8JeSq2ZjNExer',
+		date: '2024-05-17',
+	},
+	{
+		name: 'EP22:How to Check Credit Scores',
+		uri: 'spotify:episode:2CJ08Yj9nYRupDg2vLxy49',
+		date: '2024-05-10',
+	},
+	{
+		name: 'EP21:Mindful Spending Habits',
+		uri: 'spotify:episode:79MHGsVmvlapOUVuHE8Zdo',
+		date: '2024-05-03',
+	},
+	{
+		name: 'EP20:Investing in Islamic Bonds',
+		uri: 'spotify:episode:6ZRtb2KkP25EdkkEl1B4wE',
+		date: '2024-04-26',
+	},
+	{
+		name: 'EP19:Gold as an Investment',
+		uri: 'spotify:episode:1KAHylsto49yzhyx0uq46a',
+		date: '2024-04-19',
+	},
+	{
+		name: 'EP18:Taxes and Tax Returns',
+		uri: 'spotify:episode:3hk43SOOdaEhiiPf3X3s6m',
+		date: '2024-04-12',
+	},
+	{
+		name: 'EP17:Ramadan Series - Barakah and Blessings',
+		uri: 'spotify:episode:06zbbioBKil0UD0WtNd18R',
+		date: '2024-04-05',
+	},
+	{
+		name: 'EP16:Ramadan Series - Sabr and Patience',
+		uri: 'spotify:episode:0RMxWTLIarIM5hRgryAdyC',
+		date: '2024-03-29',
+	},
+	{
+		name: 'EP15:Ramadan Series - Sadaqah and Charitable Giving',
+		uri: 'spotify:episode:0WgHMOLSkH2uip2K3DiBJa',
+		date: '2024-03-08',
+	},
+	{
+		name: 'EP14:Paying Off Student Loans in Your 20s',
+		uri: 'spotify:episode:0yUeWq1LT91POZYpJjjj7o',
+		date: '2024-03-01',
+	},
+	{
+		name: 'EP13:How to Behave as an Investor',
+		uri: 'spotify:episode:628wfiGxLObkOXMsbUxtVl',
+		date: '2024-02-23',
+	},
+	{
+		name: 'EP12:More Detail on Halal Index Funds',
+		uri: 'spotify:episode:5loyndMd2sxBS63t8azmJP',
+		date: '2024-02-16',
+	},
+	{
+		name: 'EP11:Step-by-Step Guide to Investing in a Halal Index Fund',
+		uri: 'spotify:episode:4jAQucMct4q4xRAoDfwQlV',
+		date: '2024-02-09',
+	},
+	{
+		name: 'EP10:Digital Assets - Cryptocurrencies and NFTs',
+		uri: 'spotify:episode:2eCzOwSbVCM9f1wDcB6tJR',
+		date: '2024-02-02',
+	},
+	{
+		name: 'EP09:Discussing the Main Asset Classes',
+		uri: 'spotify:episode:7lfV8KwXbWAP8VGejL60OL',
+		date: '2024-01-26',
+	},
+	{
+		name: 'EP08:Preparing to Buy a Home',
+		uri: 'spotify:episode:4e3LgoMNqQ8TmnFOAiCE3n',
+		date: '2024-01-19',
+	},
+	{
+		name: 'EP07:Islamic Finance and Credit Cards',
+		uri: 'spotify:episode:6uMvez3IxHiXvBZOhmigs9',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP06:Managing Finances and Family Expectations',
+		uri: 'spotify:episode:4MjFPrXIPeAUk1oZ7YzhFj',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP05:Halal Investing and Understanding Risk',
+		uri: 'spotify:episode:6rTpTcE1MISmCBH0EKTXsS',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP04:Halal Pensions and Retirement Planning',
+		uri: 'spotify:episode:1lXKt6rSFroRM5anpsoZgb',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP03:More on Halal Investing and Personal Finance Tips',
+		uri: 'spotify:episode:1wRTbk3kJy6tH3i6uLfTQ7',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP02:Personal Finances as a Muslim Entrepreneur',
+		uri: 'spotify:episode:39166dNikKUtHU73M4C9QX',
+		date: '2024-01-12',
+	},
+	{
+		name: 'EP01:Halal Investing and Student Loans',
+		uri: 'spotify:episode:1xtw2tNCftIqvBAVJC0ogq',
+		date: '2024-01-10',
+	},
+	{
+		name: 'Trailer:Nisa Invest Tea Talk',
+		uri: 'spotify:episode:4S5aGq8tkOaxEESa0OFkkw',
+		date: '2024-11-23',
+	},
+];

--- a/src/components/SpotifyList/SpotifyList.tsx
+++ b/src/components/SpotifyList/SpotifyList.tsx
@@ -15,7 +15,7 @@ declare global {
 	}
 }
 
-function PodcastEpisodes({ episodes }: { episodes: EpisodeProp[] }) {
+function SpotifyList({ episodes }: { episodes: EpisodeProp[] }) {
 	const [currentEpisode, setCurrentEpisode] = useState<EpisodeProp | null>(
 		episodes[0] || null
 	);
@@ -57,13 +57,13 @@ function PodcastEpisodes({ episodes }: { episodes: EpisodeProp[] }) {
 	};
 
 	return (
-		<div className='flex flex-col max-w-3xl mx-auto p-4 font-source-sans text-offWhite'>
+		<div className='flex flex-col max-w-3xl mx-auto p-4 font-source-sans text-primaryBlack'>
 			<div ref={embedRef}></div>
 			<div className='h-[400px] overflow-y-auto bg-offWhite rounded-lg shadow-inner p-4 border-solid border-2 border-lilac'>
 				{episodes.map((episode, index) => (
 					<div
 						key={index}
-						className='flex justify-between items-center mb-4 bg-lilac rounded-lg shadow-md p-4'
+						className='flex justify-between items-center mb-4 bg-white rounded-lg shadow-md p-4'
 					>
 						<div>
 							<h3 className='text-lg font-semibold mb-2'>{episode.name}</h3>
@@ -79,4 +79,4 @@ function PodcastEpisodes({ episodes }: { episodes: EpisodeProp[] }) {
 	);
 }
 
-export default PodcastEpisodes;
+export default SpotifyList;

--- a/src/components/SpotifyList/SpotifyList.tsx
+++ b/src/components/SpotifyList/SpotifyList.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '../ui/button';
 
+/* Refer to documentation for help:
+ https://developer.spotify.com/documentation/embeds/tutorials/using-the-iframe-api */
+
 export interface EpisodeProp {
 	name: string;
 	uri: string;

--- a/src/components/SpotifyList/SpotifyList.tsx
+++ b/src/components/SpotifyList/SpotifyList.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Button } from '../ui/button';
+
+export interface EpisodeProp {
+	name: string;
+	uri: string;
+	date: string | Date;
+}
+
+// Extend the global Window interface to include onSpotifyIframeApiReady
+declare global {
+	interface Window {
+		onSpotifyIframeApiReady?: (IFrameAPI: any) => void;
+		SpotifyIframeApi?: any;
+	}
+}
+
+function PodcastEpisodes({ episodes }: { episodes: EpisodeProp[] }) {
+	const [currentEpisode, setCurrentEpisode] = useState<EpisodeProp | null>(
+		episodes[0] || null
+	);
+	const embedRef = useRef<HTMLDivElement>(null);
+	const [embedController, setEmbedController] = useState<any>(null);
+
+	useEffect(() => {
+		if (!window.onSpotifyIframeApiReady) {
+			window.onSpotifyIframeApiReady = (IFrameAPI) => {
+				window.SpotifyIframeApi = IFrameAPI;
+				if (embedRef.current) {
+					IFrameAPI.createController(
+						embedRef.current,
+						{ width: '100%', height: '200px' }, // Set width and height here
+						(controller: any) => {
+							setEmbedController(controller);
+							if (currentEpisode) {
+								controller.loadUri(currentEpisode.uri);
+							}
+						}
+					);
+				}
+			};
+
+			const script = document.createElement('script');
+			script.src = 'https://open.spotify.com/embed-podcast/iframe-api/v1';
+			script.async = true;
+			document.body.appendChild(script);
+		} else if (embedController && currentEpisode) {
+			embedController.loadUri(currentEpisode.uri);
+		}
+	}, [currentEpisode, embedController]);
+
+	const playEpisode = (episode: EpisodeProp) => {
+		setCurrentEpisode(episode);
+		if (embedController) {
+			embedController.loadUri(episode.uri);
+		}
+	};
+
+	return (
+		<div className='flex flex-col max-w-3xl mx-auto p-4 font-source-sans text-offWhite'>
+			<div ref={embedRef}></div>
+			<div className='h-[400px] overflow-y-auto bg-offWhite rounded-lg shadow-inner p-4 border-solid border-2 border-lilac'>
+				{episodes.map((episode, index) => (
+					<div
+						key={index}
+						className='flex justify-between items-center mb-4 bg-lilac rounded-lg shadow-md p-4'
+					>
+						<div>
+							<h3 className='text-lg font-semibold mb-2'>{episode.name}</h3>
+							<p className='text-sm mb-2'>
+								{new Date(episode.date).toLocaleDateString()}
+							</p>
+						</div>
+						<Button onClick={() => playEpisode(episode)}>Play Episode</Button>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+export default PodcastEpisodes;

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,5 +1,19 @@
+import SpotifyEmbedPlayer from '@/components/SpotifyEmbedPlayer/SpotifyEmbedPlayer';
+import { podcastEpisodes } from '@/components/SpotifyList/PodcastData';
+
 function About() {
-	return <></>;
+	return (
+		<div>
+			{/* conditional rendering expression to render Spotify Player with the latest episode if the data is present */}
+			{podcastEpisodes[0]?.uri && (
+				<SpotifyEmbedPlayer
+					width='700px'
+					height='200px'
+					uri={podcastEpisodes[0].uri}
+				/>
+			)}
+		</div>
+	);
 }
 
 export default About;


### PR DESCRIPTION
## Description

1. Added a SpotifyEmbedPlayer component that takes spotify URI as a prop + width and height as optional and displays embedded content.
2. Added Nisa Invest podcast data at ``/components/SpotifyList/PodcastData.ts``
3. Added a SpotifyList component that takes data object as a prop and returns a Spotify player and a list of episodes that can be played at a click of a button
4. Added player to About page with latest podcast episode

- Component 1
![image](https://github.com/user-attachments/assets/fecea599-f157-4c4c-a5a5-62efb140e4e0)

- Component 2
![image](https://github.com/user-attachments/assets/c02cabf5-2efe-49d4-9150-7bf5c24fa9d6)


## Related Issue
closes #36 

## How Can This Be Tested?
Use the component in any page e.g About

1. import
```typescript
import SpotifyEmbedPlayer from '@/components/SpotifyEmbedPlayer/SpotifyEmbedPlayer';

```
2. Add html element
```html
<SpotifyEmbedPlayer uri='spotify:episode:48uDebBFSKEXcbDXK8cvNZ' />

```
3. import episode list component and related data
```typescript
import SpotifyList from '@/components/SpotifyList/SpotifyList';
import { podcastEpisodes } from '@/components/SpotifyList/PodcastData';
```
4. Add html element
```html
<SpotifyList episodes={podcastEpisodes} />
```
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings, including `` npm run build ``
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)