### PR TITLE
removed final question from signup form

### DIFF
--- a/src/components/SignUpForm/SignUpForm.tsx
+++ b/src/components/SignUpForm/SignUpForm.tsx
@@ -11,33 +11,6 @@ import {
 	FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-
-/** */
-const Reasons = [
-	{
-		id: 'savings',
-		name: 'savings',
-		description: 'Grow my savings',
-	},
-	{
-		id: 'expenses',
-		name: 'expenses',
-		description: 'Learn how to manage my expenses',
-	},
-	{
-		id: 'investments',
-		name: 'investments',
-		description: 'Learn about investments',
-	},
-	{
-		id: 'community',
-		name: 'community',
-		description: 'Learn how to give back to my community',
-	},
-];
-
-// const defaultReason: string = Reasons[0]!.name!;
 
 const formSchema = z.object({
 	username: z.string().min(2, {
@@ -55,11 +28,8 @@ const formSchema = z.object({
 	password: z.string().min(8, {
 		message: 'Password must be at least 8 characters long.',
 	}),
-	reason: z.enum(['savings', 'expenses', 'investments', 'community']),
 });
 
-// I wanted reason to have the default value `defaultReason` but this caused a type error, so I've
-// hard-coded for now. Something to come back to if we have time!
 export function SignUpForm() {
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),
@@ -69,7 +39,6 @@ export function SignUpForm() {
 			firstName: '',
 			lastName: '',
 			password: '',
-			reason: 'savings',
 		},
 	});
 
@@ -162,38 +131,6 @@ export function SignUpForm() {
 											placeholder='Enter your password'
 											{...field}
 										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name='reason'
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>
-										What do you hope to get out of Nisa Invest?
-									</FormLabel>
-									<FormControl>
-										<RadioGroup
-											onValueChange={field.onChange}
-											defaultValue={field.value}
-										>
-											{Reasons.map((reason) => (
-												<FormItem className='flex items-center space-x-3 space-y-0'>
-													<FormControl>
-														<RadioGroupItem
-															value={reason.name}
-															id={reason.id}
-														/>
-													</FormControl>
-													<FormLabel className='font-normal'>
-														{reason.description}
-													</FormLabel>
-												</FormItem>
-											))}
-										</RadioGroup>
 									</FormControl>
 									<FormMessage />
 								</FormItem>


### PR DESCRIPTION
## Description
Fahan asked me to remove the question about what users are hoping to get out of the app from the form because we have the quiz. So it now looks like this:
![image](https://github.com/user-attachments/assets/ae6e7074-0aa1-454b-831e-f80955c25444)

## Related Issue
Closes #71 

## How Can This Be Tested?
Run the app and navigate to http://localhost:5173/signup and see the updated form!

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings, including `` npm run build ``
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)