### PR TITLE
changed fix-stripe-types extension name in yaml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm install
 
       - name: Fix Stripe Types
-        run: node fix-stripe-types.cjs
+        run: node fix-stripe-types.js
 
       - name: Build the project
         run: npm run build


### PR DESCRIPTION
## Description
I updated the YAML, so it's looking for the file with the correct `.js` extension. Hopefully this fixes the build error!

## How Can This Be Tested?
Check Github Actions after merging